### PR TITLE
fix dangling pointer and refcount for solution array

### DIFF
--- a/scipybiteopt/biteopt_py_ext.cpp
+++ b/scipybiteopt/biteopt_py_ext.cpp
@@ -9,6 +9,10 @@
 
 extern "C" {
 
+static void biteoptCleanup(PyObject *capsule) {
+    free(PyCapsule_GetPointer(capsule, NULL));
+}
+
 static PyObject* minimize_func(PyObject* self, PyObject* args, PyObject *kwargs)
 {
     std::vector<double> upper, lower;
@@ -74,7 +78,7 @@ static PyObject* minimize_func(PyObject* self, PyObject* args, PyObject *kwargs)
             return 0;
         }
     }
-    std::vector<double> best_x(lower.size());
+    double* best_x = (double*) calloc(lower.size(), sizeof(double));
     double min_f;
     int n_fev;
    
@@ -101,7 +105,7 @@ static PyObject* minimize_func(PyObject* self, PyObject* args, PyObject *kwargs)
     };
 
     FuncData fdata = {func_py}; // maybe add pass-thru args later
-    n_fev = biteopt_minimize( lower.size(), closure, (void*)&fdata, lower.data(), upper.data(), best_x.data(), &min_f, iter_py,M_py,attc_py, stopc_py);
+    n_fev = biteopt_minimize( lower.size(), closure, (void*)&fdata, lower.data(), upper.data(), best_x, &min_f, iter_py,M_py,attc_py, stopc_py);
 
     PyObject *fun = PyFloat_FromDouble(min_f);
     PyObject *nfev = PyLong_FromLong(n_fev);
@@ -109,10 +113,11 @@ static PyObject* minimize_func(PyObject* self, PyObject* args, PyObject *kwargs)
     int dimensions = lower.size();
     dims_res[0] = dimensions;
 
-    PyObject *res = PyArray_SimpleNewFromData(1, dims_res,NPY_DOUBLE,(void *)best_x.data());
-    PyArray_ENABLEFLAGS((PyArrayObject*) res, NPY_ARRAY_OWNDATA);
+    PyObject *res = PyArray_SimpleNewFromData(1, dims_res,NPY_DOUBLE,(void *)best_x);
+    PyObject *capsule = PyCapsule_New(best_x, NULL, biteoptCleanup);
+    PyArray_SetBaseObject((PyArrayObject*) res, capsule);
     PyObject *result = PyTuple_Pack(3, fun, res, nfev);
-    //Py_DECREF(fun);  
+    Py_DECREF(res);
     return result;
 }
 


### PR DESCRIPTION
I've ported one of biteopt's examples [(`constr.cpp`)](https://github.com/avaneev/biteopt/blob/master/constr.cpp) to Python [(`constr.py`)](https://gist.github.com/notwa/44729b0e5a88c65bacd1ffa2564b0254), and judging by the number of iterations it takes, biteopt seems to arrive at the same solution. however, the first two values of `res.x` have been overwritten by pointers.

the first four values printed here are the first four values of res.x, as a big-endian hex-dump — notice the inconsistency in objective value as well:

```
################################
000001752B733910
000001752B793A30
3FF0000000000000
3FF0000000000000
-15.0 versus 1584628871905.0857
################################
Finished at iteration 34149
Objective = -15
Constraints not met: 2
x[0] = 0.000000
x[1] = 0.000000
x[2] = 1.000000
x[3] = 1.000000
x[4] = 1.000000
x[5] = 1.000000
x[6] = 1.000000
x[7] = 1.000000
x[8] = 1.000000
x[9] = 3.000000
x[10] = 3.000000
x[11] = 3.000000
x[12] = 1.000000
```

I tried this on Linux, but it only seems to become apparent on Windows builds — I suppose Windows is more eager to re-use that memory. in any case, the culprit is [here, in biteopt_py_ext.cpp.](https://github.com/dschmitz89/scipybiteopt/blob/b654906/scipybiteopt/biteopt_py_ext.cpp#L77) best_x is allocated on stack¹, which is freed for use as the function exits.

my solution is to replace the STL container with a simple `calloc`, and then deal with the resulting memory leak. I looked around online and found that using a PyCapsule with numpy's SetBaseObject method to "steal the reference" allowed me to specify a simple deconstructor/deallocator. I've also removed the `NPY_ARRAY_OWNDATA` flag because it appears to be something specific to numpy's own internal allocator, and I've decremented the reference counter on the array itself since the result tuple creates its own reference. I've done some crude `printf` experiments to make sure the cleanup function is being called (it was not without the decrement).

¹ or heap. I don't remember the semantics of where the C++ STL allocates its non-`new` memory.

…well, that wound up being much longer of a post than I intended. 😅 also, feel free to adapt `constr.py` if it is useful to you.